### PR TITLE
Releasing a mouse lock back to where the lock was initiated

### DIFF
--- a/Assets/_theGAME/scripts/CameraController.cs
+++ b/Assets/_theGAME/scripts/CameraController.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 [AddComponentMenu("Camera Controllers/Better Mouse Orbit")]
 public class CameraController : MonoBehaviour
@@ -69,9 +69,9 @@ public class CameraController : MonoBehaviour
 
             // cursor locked?
             if (panLocksMouse) {
-                Cursor.lockState = mouseButtonActive ? CursorLockMode.Confined : CursorLockMode.None;
+                MousePointer.lockState = mouseButtonActive ? CursorLockMode.Locked : CursorLockMode.None;
                 // cursor visible when mouse is not active
-                Cursor.visible = !mouseButtonActive;
+                MousePointer.visible = !mouseButtonActive;
             }
 
             if (mouseButtonActive)

--- a/Assets/_theGAME/scripts/MousePointer.cs
+++ b/Assets/_theGAME/scripts/MousePointer.cs
@@ -1,0 +1,156 @@
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+/// <summary>
+/// A Wrapper API for UnityEngine.Cursor.
+/// <para>Use this the same as you would the UnityEngine.Cursor API, but enjoy the fact that locking
+/// and unlocking the cursor will restore the mouse pointer to the position before it was locked.</para>
+/// <para>Also provides a static property for reading and writing the mouse position.</para>
+/// <para>See MSDN docs' GetCursorPos and SetCursorPos, as well as Unity3D docs' UnityEngine.Cursor</para>
+/// </summary>
+/// <example>
+///   void Update(){
+///       if(Input.GetMouseButtonDown(0)){ // if the left mouse button was just pressed, then:
+///           // show fake cursor on screen where lock will be initiated, 
+///           //   using Input.mousePosition to determine the placement in the window.
+///           // *poof* -- example not shown.
+///       } else if(Input.GetMouseButtonUp(0)) { // else if the left mouse button was just released, then:
+///           // hide fake cursor on the screen.
+///           // *poof* -- example not shown.
+///       }
+///   
+///       bool lockMouse = Input.GetMouseButton(0); // is the left mouse button held?
+///       
+///       // initiate a mouse lock if left mouse button is held, release otherwise:
+///       MousePointer.lockMode = lockMouse ? CursorLockMode.Locked : CursorLockMode.None; 
+///       // releasing after locking using MousePointer.lockMode instead of Unity's Cursor.lockMode will
+///       //   automatically move the cursor back to where it was just before the lock was initiated.
+///       
+///       // hide cursor because Unity will technically center the cursor on the screen while locked:
+///       MousePointer.visible = !lockMouse;
+///   }
+/// </example>
+internal class MousePointer {
+
+    #region User32 Cursor Position Manipulation
+
+    /// <summary>
+    /// (Private) A structure that defines an x- and y- coordinate on the screen.
+    /// Used exclusively to store a mouse's position coordinates.
+    /// <para>See MSDN docs' POINT structure</para>
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MousePosition {
+        public int x;
+        public int y;
+
+        public MousePosition(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    /// <summary>
+    /// (Private) Moves the cursor to the specified screen coordinates.
+    /// <para>See MSDN docs' SetCursorPos()</para>
+    /// </summary>
+    /// <param name="x">The new x-coordinate of the cursor.</param>
+    /// <param name="y">The new y-coordinate of the cursor.</param>
+    /// <returns>Returns true if successful, false otherwise.</returns>
+    [DllImport("User32.dll")]
+    private static extern bool SetCursorPos(int x, int y);
+
+    /// <summary>
+    /// (Private) Moves the cursor to the specified screen coordinates.
+    /// </summary>
+    /// <param name="position">The new position of the cursor.</param>
+    /// <returns>Returns true if successful, false otherwise.</returns>
+    private static bool SetCursorPos(MousePosition position) {
+        return SetCursorPos(position.x, position.y);
+    }
+
+    /// <summary>
+    /// Retrieves the position of the mouse cursor, in screen coordinates.
+    /// <para>See MSDN docs' GetCursorPos()</para>
+    /// </summary>
+    /// <param name="position">A pointer to a POINT structure that receives the screen coordinates of the cursor.</param>
+    /// <returns>Returns true if successful or false otherwise.</returns>
+    [DllImport("User32.dll")]
+    private static extern bool GetCursorPos(out MousePosition position);
+
+    #endregion User32 Cursor Position Manipulation
+
+    #region Wrapper API for UnityEngine.Cursor
+
+    /// <summary>
+    /// (Private) Represents the last position the mouse was at before the cursor was locked.
+    /// <para>Used for restoring the mouse to its former position when unlocking the cursor.</para>
+    /// </summary>
+    private static MousePosition lastMousePosition = new MousePosition { x = 0, y = 0 };
+
+    /// <summary>Represents and controls the mouse's position on the screen as a Vector2.</summary>
+    public static Vector2 position {
+        get {
+            MousePosition p;
+            if (GetCursorPos(out p)) return new Vector2(p.x, p.y);
+            return Vector2.zero;
+        }
+        set {
+            MousePosition p = new MousePosition((int)value.x, (int)value.y);
+            SetCursorPos(p);
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the hardware pointer is visible or not.
+    /// <para>See Unity3D docs' UnityEngine.Cursor.visible</para>
+    /// </summary>
+    public static bool visible {
+        get { return Cursor.visible; }
+        set { Cursor.visible = value; }
+    }
+
+    /// <summary>
+    /// Determines whether the hardware pointer is locked to the center of the view, constrained to the window, or not constrained at all.
+    /// <para>Restores the cursor to its position prior to being locked when you set the lockState to CursorLockMode.None.</para>
+    /// <para>See Unity3D docs' UnityEngine.Cursor.lockState</para>
+    /// </summary>
+    public static CursorLockMode lockState {
+        get { return Cursor.lockState; }
+        set {
+            switch (value) {
+                case CursorLockMode.Locked:
+                    if (Cursor.lockState == CursorLockMode.Locked) return;
+                    Cursor.visible = false;
+                    MousePosition position;
+                    if (GetCursorPos(out position))
+                        lastMousePosition = position;
+                    Cursor.lockState = CursorLockMode.Locked;
+                    break;
+
+                default:
+                    if (Cursor.lockState == CursorLockMode.Locked) {
+                        Cursor.lockState = value;
+                        Cursor.visible = false;
+                        //lastMousePosition.x += (int)Input.GetAxisRaw("Mouse X");
+                        //lastMousePosition.y += (int)-Input.GetAxisRaw("Mouse Y");
+                        SetCursorPos(lastMousePosition);
+                        Cursor.visible = true;
+                    } else {
+                        Cursor.lockState = value;
+                    }
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Specify a custom cursor that you wish to use as a cursor.
+    /// <para>See Unity3D docs' UnityEngine.Cursor.SetCursor()</para>
+    /// </summary>
+    public static void SetCursor(Texture2D texture, Vector3 hotspot, CursorMode mode) {
+        Cursor.SetCursor(texture, hotspot, mode);
+    }
+
+    #endregion Wrapper API for UnityEngine.Cursor
+}

--- a/Assets/_theGAME/scripts/MousePointer.cs.meta
+++ b/Assets/_theGAME/scripts/MousePointer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 701acf6561b99d746856e01691456435
+timeCreated: 1497215889
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_theGAME/scripts/PlayerController.cs
+++ b/Assets/_theGAME/scripts/PlayerController.cs
@@ -14,6 +14,7 @@ public class PlayerController : PunBehaviour {
 
     [Tooltip("The local player instance. Use this to know if the local player is represented in the Scene")]
     public static GameObject localPlayer;
+    public bool isLocalPlayer { get { return photonView.isMine; } }
     
     public float rotationSlerpSpeed = 224f;
 
@@ -31,9 +32,9 @@ public class PlayerController : PunBehaviour {
         cameraController = mainCamera.GetComponent<CameraController>();
         
         // keep track of the localPlayer to prevent instantiation when levels are synchronized
-        if (photonView.isMine) {
+        if (isLocalPlayer) {
             localPlayer = this.gameObject;
-            Camera.main.GetComponent<CameraController>().target = transform;
+            cameraController.target = transform;
         }
     }
 
@@ -43,7 +44,7 @@ public class PlayerController : PunBehaviour {
         playerCanvas = transform.Find("Player Canvas");
         txtPlayerUsername.text = photonView.owner.NickName;
 
-        if (photonView.isMine) {
+        if (isLocalPlayer) {
             GetComponent<MeshRenderer>().material.color = new Color(8/255f, 168/255f, 241/255f, 1);
             //GetComponent<MeshRenderer>().material.color = new Color(0x08/ 255f, 0xA8/255f, 0xF1/255f, 1);
             //GetComponent<MeshRenderer>().material.color = new Color32(8, 168, 241, 255);
@@ -52,7 +53,7 @@ public class PlayerController : PunBehaviour {
     }
 
     void Update() {
-        if (!photonView.isMine) return;
+        if (!isLocalPlayer) return;
         
         var x = Input.GetAxis("Horizontal") * Time.deltaTime * 3.0f;
         var z = Input.GetAxis("Vertical") * Time.deltaTime * 3.0f;
@@ -95,12 +96,12 @@ public class PlayerController : PunBehaviour {
     }
 
     private void OnTriggerEnter(Collider other) {
-        if (!localPlayer) return;
+        if (!isLocalPlayer) return;
         if (other.CompareTag("Respawn Shield")) Respawn();
     }
     
     public void Respawn() {
-        if (!localPlayer) return;
+        if (!isLocalPlayer) return;
 
         Debug.Log("Choosing a spawn point.");
         // Default spawn point
@@ -117,13 +118,13 @@ public class PlayerController : PunBehaviour {
     }
 
     public void playerFade(float alphaValue) {
-        if (localPlayer) {
-            MeshRenderer[] renderers = localPlayer.GetComponentsInChildren<MeshRenderer>();
-            for (int i = 0; i < renderers.Length; i++) {
-                Color color = renderers[i].material.color;
-                color.a = Mathf.Clamp(color.a + alphaValue, 0, 1);
-                renderers[i].material.color = color;
-            }
+        if (!isLocalPlayer) return;
+
+        MeshRenderer[] renderers = localPlayer.GetComponentsInChildren<MeshRenderer>();
+        for (int i = 0; i < renderers.Length; i++) {
+            Color color = renderers[i].material.color;
+            color.a = Mathf.Clamp(color.a + alphaValue, 0, 1);
+            renderers[i].material.color = color;
         }
     }
 }


### PR DESCRIPTION
This introduces a new class that wraps the `UnityEngine.Cursor` api and `user32.dll`'s [SetCursorPos](https://msdn.microsoft.com/en-us/library/windows/desktop/ms648394(v=vs.85).aspx) & [GetCursorPos](https://msdn.microsoft.com/en-us/library/windows/desktop/ms648390(v=vs.85).aspx) methods. The only key difference in behavior between the new class, `MousePointer`, and the `UnityEngine.Cursor` class is that the mouse's position will be reset back to where it was just before the `lockState` was set to `Locked`.

Technically while the mouse is locked the cursor is at the center of the game window, same as before, but the user can't tell that this is the case because the mouse is hidden automatically when the lock is initiated and is only shown later when it is released & restored to its former position. 
If we wanted to show the mouse exactly where the lock was initiated while locked, it will need to be faked using a sprite or texture in the game scene.

<br><br>

Additionally included in this PR:
- A getter/setter property `MousePointer.position` that makes it trivial for any script to manipulate the position of the mouse cursor.
- A bugfix for the PlayerController where it was checking whether or not its static property `localPlayer` is null, as a test for whether or not the method is being called on the player's local character (an erroneous thing to test because `localPlayer` is a static property and checking its nullness results in a `true` regardless of which PlayerController's logic is being executed). It has now been rewritten to properly check if the PlayerController belongs to the local player using a new getter property called `isLocalPlayer`.