### PR TITLE
"Ghostify" the Player & Visor while using the Standard Shader (a.k.a. player shadows are back)

### DIFF
--- a/Assets/_theGAME/Resources/teamTALIMA Player.prefab
+++ b/Assets/_theGAME/Resources/teamTALIMA Player.prefab
@@ -44,6 +44,7 @@ GameObject:
   - component: {fileID: 114698527043586634}
   - component: {fileID: 114019161044576486}
   - component: {fileID: 114650690372497238}
+  - component: {fileID: 114965930464659220}
   m_Layer: 8
   m_Name: teamTALIMA Player
   m_TagString: Untagged
@@ -62,6 +63,7 @@ GameObject:
   - component: {fileID: 33831372376325754}
   - component: {fileID: 65333479824752920}
   - component: {fileID: 23145143255390266}
+  - component: {fileID: 114095373605477640}
   m_Layer: 8
   m_Name: Visor
   m_TagString: Untagged
@@ -93,7 +95,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1416093075307488}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4356724533618858}
@@ -300,6 +302,18 @@ MonoBehaviour:
     InterpolateOption: 0
     InterpolateMoveTowardsSpeed: 1
     InterpolateLerpSpeed: 0
+--- !u!114 &114095373605477640
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1533057662892516}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17bbbd85cdbb666498be4b930b5b063c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  renderQueue: 3001
 --- !u!114 &114456115385333230
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -366,6 +380,18 @@ MonoBehaviour:
   instantiationId: -1
   currentMasterID: -1
   isRuntimeInstantiated: 0
+--- !u!114 &114965930464659220
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1416093075307488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17bbbd85cdbb666498be4b930b5b063c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  renderQueue: 3000
 --- !u!114 &114998741354410024
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/_theGAME/materials/Black.mat
+++ b/Assets/_theGAME/materials/Black.mat
@@ -7,12 +7,14 @@ Material:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: Black
-  m_Shader: {fileID: 4800000, guid: 3a5515e22bc2d7d499ef99804543dda5, type: 3}
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: _ALPHABLEND_ON _EMISSION
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
   m_CustomRenderQueue: 3001
-  stringTagMap: {}
+  stringTagMap:
+    RenderType: Transparent
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
@@ -70,7 +72,7 @@ Material:
     - _SpecularHighlights: 1
     - _SrcBlend: 5
     - _UVSec: 0
-    - _ZWrite: 0
+    - _ZWrite: 1
     m_Colors:
     - _Color: {r: 0, g: 0, b: 0, a: 1}
     - _Emission: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/_theGAME/materials/ttBlue.mat
+++ b/Assets/_theGAME/materials/ttBlue.mat
@@ -7,12 +7,14 @@ Material:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_Name: ttBlue
-  m_Shader: {fileID: 4800000, guid: 3a5515e22bc2d7d499ef99804543dda5, type: 3}
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: _ALPHABLEND_ON
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
   m_CustomRenderQueue: 3000
-  stringTagMap: {}
+  stringTagMap:
+    RenderType: Transparent
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
@@ -113,7 +115,7 @@ Material:
     - _SquashAmount: 1
     - _SrcBlend: 5
     - _UVSec: 0
-    - _ZWrite: 0
+    - _ZWrite: 1
     m_Colors:
     - _Color: {r: 0.03137255, g: 0.65882355, b: 0.94509804, a: 1}
     - _Emission: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/_theGAME/scripts/Ghostify.cs
+++ b/Assets/_theGAME/scripts/Ghostify.cs
@@ -19,7 +19,7 @@ public class Ghostify : MonoBehaviour {
         // ^ These two are the only lines you need to get the standard shader to 
         //   write to the z-buffer regardless of the material being Transparent or Fade.
         // - Setting the renderQueue is more or less to help you stop z-buffer problems 
-        //   with multiple ghost objects. 2500 for the Player, 2501 for the Visor, etc...
+        //   with multiple ghost objects. 3000 for the Player, 3001 for the Visor, etc...
     }
 
     void OnValidate() {

--- a/Assets/_theGAME/scripts/Ghostify.cs
+++ b/Assets/_theGAME/scripts/Ghostify.cs
@@ -1,0 +1,41 @@
+﻿using UnityEngine;
+
+[ExecuteInEditMode]
+public class Ghostify : MonoBehaviour {
+    Material material;
+    int prevZWrite;
+    int prevRenderQueue;
+
+    [SerializeField]
+    int renderQueue = 3000;
+
+    void OnEnable() {
+        material = Application.isPlaying ? GetComponent<MeshRenderer>().material : GetComponent<MeshRenderer>().sharedMaterial;
+        prevZWrite = material.GetInt("_ZWrite");
+        prevRenderQueue = material.renderQueue;
+
+        material.SetInt("_ZWrite", 1);
+        material.renderQueue = renderQueue;
+        // ^ These two are the only lines you need to get the standard shader to 
+        //   write to the z-buffer regardless of the material being Transparent or Fade.
+        // - Setting the renderQueue is more or less to help you stop z-buffer problems 
+        //   with multiple ghost objects. 2500 for the Player, 2501 for the Visor, etc...
+    }
+
+    void OnValidate() {
+        if(enabled && material != null) {
+            material.SetInt("_ZWrite", 1);
+            material.renderQueue = renderQueue;
+        } else {
+            OnDisable();
+        }
+    }
+
+    void OnDisable() {
+        if(material != null) {
+            material.SetInt("_ZWrite", prevZWrite);
+            material.renderQueue = prevRenderQueue;
+            material = null;
+        }
+    }
+}

--- a/Assets/_theGAME/scripts/Ghostify.cs.meta
+++ b/Assets/_theGAME/scripts/Ghostify.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 17bbbd85cdbb666498be4b930b5b063c
+timeCreated: 1500683015
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Summary: The Player now casts shadows while using the old the built-in Standard shader, but with the material's `_ZWrite` enabled to prevent fading from revealing visor.

-------------------

Adds a new script (Ghostify.cs) that modifies some properties of the material of its GameObject, forcing the material to write to the z-buffer. It allows using the Fade(/Transparent) Standard shader (Shadows + Nicer Surface Lighting) while also maintaining the "Ghost" transparency effect.

⚠️ **Note**: I updated my Unity installation to Unity 2017.1.0f3. I don't think there will be any problem merging this pull, but it's worth mentioning just in case they've changed something about the data structure in the meta files that isn't backwards compatible. Might want to consider updating Unity yourself (you'll have to grab the latest version of PUN though).

<br>

![](https://user-images.githubusercontent.com/905015/28487023-1182df10-6e3e-11e7-8745-8596d22272ab.gif)
*Animated Image: demonstrating the same fade-in mechanic as before, but now shadows are back!*

<br>

👍 